### PR TITLE
Use only one rebar erl_opts

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,11 +1,10 @@
 %% -*- mode: erlang;erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %% ex: ts=4 sw=4 ft=erlang et
 
-{erl_opts, [{parse_transform, lager_transform}]}.
-
 {erl_opts, [warnings_as_errors,
             warn_export_all,
-            warn_unused_import]}.
+            warn_unused_import,
+            {parse_transform, lager_transform}]}.
 
 {erl_first_files, ["src/gen_logger.erl"]}.
 


### PR DESCRIPTION
I had problems with rebar3 when it found two erl_opts. The last erl_opts options is always used.

So, merging the two erl_opts fixes the problem.